### PR TITLE
strip debugging and symbol table from compiled binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 on:
   - pull_request
   - push
+permissions:
+  packages: write
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
             GIT_REPO=${{ steps.docker.outputs.gitRepo }}
             VERSION=${{ steps.docker.outputs.version }}
           platforms: ${{ steps.docker.outputs.platforms }}
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.docker.outputs.image_name }}
 
       - name: Run GoReleaser

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV GOOS=linux
 ENV PROJECT_NAME="${PROJECT_NAME}"
 RUN go build \
   -ldflags \
-  "-X $GIT_REPO/cmd.Version=$VERSION -X $GIT_REPO/cmd.GitCommit=$GIT_COMMIT" \
+  "-w -s -X $GIT_REPO/cmd.Version=$VERSION -X $GIT_REPO/cmd.GitCommit=$GIT_COMMIT" \
   -o /app/app
 ENTRYPOINT /app/app
 


### PR DESCRIPTION
## Description

Add the `-s` and `-w` flags to the compile process inside the `Dockerfile`.

## How to test

build on `main` and the branch, and you should see something like the following

```
docker images | grep gobblr
gobblr-stripped                                 latest            0b6c72a360e5   28 seconds ago   34.1MB
gobblr-original                                 latest            6acecc4bd509   2 minutes ago    44.4MB
```
